### PR TITLE
Correct shebang of /usr/bin/pgAdmin4

### DIFF
--- a/dev-db/pgadmin4/pgadmin4-6.5.ebuild
+++ b/dev-db/pgadmin4/pgadmin4-6.5.ebuild
@@ -179,7 +179,7 @@ src_install() {
 
 	insinto /usr/bin
 	newins - pgAdmin4 <<-EOF
-	#/bin/bash
+	#!/bin/bash
 	cd /usr/share/pgadmin4/runtime
 	node_modules/nw/nwjs/nw .
 	EOF


### PR DESCRIPTION
The error is hidden when starting `pgAdmin4` from the console, as shell is implied. However, starting pgAdmin4 e.g. from the KDE desktop entry fails with `execvp` error as KDE attempts to start it as binary due to lack of shebang (indeed, that's just a comment without exclamation mark).

Correcting it to what it should be to begin with.